### PR TITLE
Use Theme brightness instead of FadeTheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,17 @@ A fade shimmer library to implement loading like latest facebook loading effect.
 ## example
 create rounded loading
 ```
-      FadeShimmer.round(
-        size: 60,
-        fadeTheme: isDarkMode ? FadeTheme.dark : FadeTheme.light,
-      )
+FadeShimmer.round(
+  size: 60,
+)
 ```
 create loading with custom size and color
 ```
-      FadeShimmer(
-        height: 8,
-        width: 150,
-        radius: 4,
-        highlightColor: Color(0xffF9F9FB),
-        baseColor: Color(0xffE6E8EB),
-      )
+FadeShimmer(
+  height: 8,
+  width: 150,
+  radius: 4,
+  baseColor: Color(0xffE6E8EB),
+  highlightColor: Color(0xffF9F9FB),
+)
 ```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,45 +5,56 @@ void main() {
   runApp(MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
+  @override
+  _MyAppState createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  bool isDarkMode = true;
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        accentColor: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
+        scaffoldBackgroundColor: Color(0xffF0F2F5),
+        cardColor: Colors.white,
       ),
+      darkTheme: ThemeData(
+        accentColor: Colors.blue,
+        visualDensity: VisualDensity.adaptivePlatformDensity,
+        brightness: Brightness.dark,
+        scaffoldBackgroundColor: Color(0xff181818),
+        cardColor: Color(0xff242424),
+      ),
+      themeMode: isDarkMode ? ThemeMode.dark : ThemeMode.light,
       debugShowCheckedModeBanner: false,
-      home: LoadingPage(),
-    );
-  }
-}
-
-class LoadingPage extends StatefulWidget {
-  const LoadingPage({Key? key}) : super(key: key);
-
-  @override
-  _LoadingPageState createState() => _LoadingPageState();
-}
-
-class _LoadingPageState extends State<LoadingPage> {
-  bool isDarkMode = true;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: isDarkMode ? Color(0xff181818) : Color(0xffF0F2F5),
-      floatingActionButton: FloatingActionButton(
-        child: Icon(
-          Icons.wb_sunny,
-          color: Colors.white.withOpacity(isDarkMode ? 0.5 : 1),
-        ),
-        onPressed: () {
+      home: LoadingPage(
+        onTap: () {
           setState(() {
             isDarkMode = !isDarkMode;
           });
         },
+      ),
+    );
+  }
+}
+
+class LoadingPage extends StatelessWidget {
+  const LoadingPage({Key? key, required this.onTap}) : super(key: key);
+
+  final void Function() onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        child: Icon(
+          Icons.wb_sunny,
+        ),
+        onPressed: onTap,
       ),
       body: Container(
         child: ListView.separated(
@@ -51,7 +62,7 @@ class _LoadingPageState extends State<LoadingPage> {
             final delay = (i * 300);
             return Container(
               decoration: BoxDecoration(
-                  color: isDarkMode ? Color(0xff242424) : Colors.white,
+                  color: Theme.of(context).cardColor,
                   borderRadius: BorderRadius.circular(8)),
               margin: EdgeInsets.symmetric(horizontal: 16),
               padding: EdgeInsets.all(16),
@@ -59,7 +70,6 @@ class _LoadingPageState extends State<LoadingPage> {
                 children: [
                   FadeShimmer.round(
                     size: 60,
-                    fadeTheme: isDarkMode ? FadeTheme.dark : FadeTheme.light,
                     millisecondsDelay: delay,
                   ),
                   SizedBox(
@@ -73,8 +83,6 @@ class _LoadingPageState extends State<LoadingPage> {
                         width: 150,
                         radius: 4,
                         millisecondsDelay: delay,
-                        fadeTheme:
-                        isDarkMode ? FadeTheme.dark : FadeTheme.light,
                       ),
                       SizedBox(
                         height: 6,
@@ -84,8 +92,6 @@ class _LoadingPageState extends State<LoadingPage> {
                         millisecondsDelay: delay,
                         width: 170,
                         radius: 4,
-                        fadeTheme:
-                        isDarkMode ? FadeTheme.dark : FadeTheme.light,
                       ),
                     ],
                   )

--- a/lib/fade_shimmer.dart
+++ b/lib/fade_shimmer.dart
@@ -7,8 +7,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-enum FadeTheme { light, dark }
-
 class FadeShimmer extends StatefulWidget {
   final Color? highlightColor;
   final Color? baseColor;
@@ -16,40 +14,31 @@ class FadeShimmer extends StatefulWidget {
   final double width;
   final double height;
 
-  /// light or dark with predefined highlightColor and baseColor
-  /// need to pass this or highlightColor and baseColor
-  final FadeTheme? fadeTheme;
-
-  /// delay time before update the color, use this to make loading items animate follow each other instead of parallel, check the example for demo.
+  //delay time before update the color, use this to make loading items animate follow each other instead of parallel, check the example for demo.
   final int millisecondsDelay;
 
   const FadeShimmer(
       {Key? key,
       this.millisecondsDelay = 0,
       this.radius = 0,
-      this.fadeTheme,
       this.highlightColor,
       this.baseColor,
       required this.width,
       required this.height})
-      : assert(
-            (highlightColor != null && baseColor != null) || fadeTheme != null),
-        super(key: key);
+      : super(key: key);
 
-  /// use this to create a round loading widget
-  factory FadeShimmer.round(
-          {required double size,
-          Color? highlightColor,
-          int millisecondsDelay = 0,
-          Color? baseColor,
-          FadeTheme? fadeTheme}) =>
+  factory FadeShimmer.round({
+    required double size,
+    Color? highlightColor,
+    int millisecondsDelay = 0,
+    Color? baseColor,
+  }) =>
       FadeShimmer(
         height: size,
         width: size,
         radius: size / 2,
         baseColor: baseColor,
         highlightColor: highlightColor,
-        fadeTheme: fadeTheme,
         millisecondsDelay: millisecondsDelay,
       );
 
@@ -64,32 +53,22 @@ class _FadeShimmerState extends State<FadeShimmer> {
   bool isHighLight = true;
   late StreamSubscription sub;
 
-  Color get highLightColor {
-    if (widget.fadeTheme != null) {
-      switch (widget.fadeTheme) {
-        case FadeTheme.light:
-          return Color(0xffF9F9FB);
-        case FadeTheme.dark:
-          return Color(0xff3A3E3F);
-        default:
-          return Color(0xff3A3E3F);
-      }
+  Color get themeHighLightColor {
+    switch (Theme.of(context).brightness) {
+      case Brightness.light:
+        return Color(0xffF9F9FB);
+      case Brightness.dark:
+        return Color(0xff3A3E3F);
     }
-    return widget.highlightColor!;
   }
 
-  Color get baseColor {
-    if (widget.fadeTheme != null) {
-      switch (widget.fadeTheme) {
-        case FadeTheme.light:
-          return Color(0xffE6E8EB);
-        case FadeTheme.dark:
-          return Color(0xff2A2C2E);
-        default:
-          return Color(0xff2A2C2E);
-      }
+  Color get themeBaseColor {
+    switch (Theme.of(context).brightness) {
+      case Brightness.light:
+        return Color(0xffE6E8EB);
+      case Brightness.dark:
+        return Color(0xff2A2C2E);
     }
-    return widget.baseColor!;
   }
 
   @override
@@ -128,7 +107,9 @@ class _FadeShimmerState extends State<FadeShimmer> {
       width: widget.width,
       height: widget.height,
       decoration: BoxDecoration(
-          color: isHighLight ? highLightColor : baseColor,
+          color: isHighLight
+              ? widget.highlightColor ?? themeHighLightColor
+              : widget.baseColor ?? themeBaseColor,
           borderRadius: BorderRadius.circular(widget.radius)),
     );
   }

--- a/test/fade_shimmer_test.dart
+++ b/test/fade_shimmer_test.dart
@@ -6,7 +6,6 @@ void main() {
       (WidgetTester tester) async {
     final widget = FadeShimmer.round(
       size: 60,
-      fadeTheme: FadeTheme.dark,
       millisecondsDelay: 0,
     );
     expect(widget, isA<FadeShimmer>());


### PR DESCRIPTION
Instead of using a custom enum to define dark/light theme, let's instead use `Theme.of(context).brightness` to decide colors, since it's more aligned with official flutter widgets. The colors from Theme will be used as fallback colors in case baseColor and highlightColor aren't defined.

This shouldn't affect how the widget looks.